### PR TITLE
Use UPConfig for user-profile representation

### DIFF
--- a/src/main/java/de/adorsys/keycloak/config/model/RealmImport.java
+++ b/src/main/java/de/adorsys/keycloak/config/model/RealmImport.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import org.keycloak.representations.idm.AuthenticationFlowRepresentation;
 import org.keycloak.representations.idm.RealmRepresentation;
+import org.keycloak.representations.userprofile.config.UPConfig;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
@@ -34,7 +35,7 @@ import java.util.Map;
 public class RealmImport extends RealmRepresentation {
     private List<AuthenticationFlowImport> authenticationFlowImports;
 
-    private Map<String, List<Map<String, Object>>> userProfile;
+    private UPConfig userProfile;
 
     private Map<String, Map<String, String>> messageBundles;
 
@@ -56,7 +57,7 @@ public class RealmImport extends RealmRepresentation {
 
     @SuppressWarnings("unused")
     @JsonSetter("userProfile")
-    public void setUserProfile(Map<String, List<Map<String, Object>>> userProfile) {
+    public void setUserProfile(UPConfig userProfile) {
         this.userProfile = userProfile;
     }
 
@@ -70,7 +71,7 @@ public class RealmImport extends RealmRepresentation {
         this.messageBundles = messageBundles;
     }
 
-    public Map<String, List<Map<String, Object>>> getUserProfile() {
+    public UPConfig getUserProfile() {
         return userProfile;
     }
 

--- a/src/main/java/de/adorsys/keycloak/config/service/UserProfileImportService.java
+++ b/src/main/java/de/adorsys/keycloak/config/service/UserProfileImportService.java
@@ -57,7 +57,7 @@ public class UserProfileImportService {
 
     private String buildUserProfileConfigurationString(RealmImport realmImport) {
         var userProfile = realmImport.getUserProfile();
-        if (userProfile == null || userProfile.isEmpty()) {
+        if (userProfile == null) {
             return null;
         }
         return JsonUtil.toJson(userProfile);


### PR DESCRIPTION
This adds support for `unmanagedAttributePolicy`

The following example configuration can correctly be imported into Keycloak 25.0.1 with this.

```yml
realm: up-demo
enabled: true
displayName: "UP Demo"

attributes:
  userProfileEnabled: true

userProfile:
  attributes:
    - name: username
      displayName: "${username}"
      validations:
        length:
          min: 3
          max: 255
    - name: email
      displayName: "${email}"
      validations:
        length:
          max: 255
    - name: firstName
      displayName: "${firstName}"
      required:
        roles:
          - user
      permissions:
        view:
          - admin
          - user
        edit:
          - admin
          - user
      validations:
        length:
          max: 255
    - name: lastName
      displayName: "${lastName}"
      required:
        roles:
          - user
      permissions:
        view:
          - admin
          - user
        edit:
          - admin
          - user
      validations:
        length:
          max: 255
    - name: phoneNumber
      displayName: "${phoneNumber}"
      annotations:
        inputType: "html5-tel"
      validations:
        length:
          min: 6
          max: 64
      required:
        roles:
          - user
        scopes:
          - "phone"
      selector:
        scopes: [ "phone" ]
      permissions:
        view:
          - user
          - admin
        edit:
          - user
          - admin

  unmanagedAttributePolicy: ADMIN_VIEW

```